### PR TITLE
Fallback on event.target

### DIFF
--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -101,7 +101,9 @@ class D3SeatingChart {
         let activeLayer = selection.selectAll('.focused > *');
         let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
         let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
-        if (!parentWidth || !parentHeight) return;
+        if (!parentWidth || !parentHeight) {
+            throw new Error('SVG dimensions must be postive values ' + this.element.outerHTML);
+        }
         let desiredWidth = parentWidth - this.margin * 2;
         let desiredHeight = parentHeight - this.margin * 2;
         let widthRatio = desiredWidth / boundingBox.width;

--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -102,7 +102,7 @@ class D3SeatingChart {
         let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
         let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
         if (!parentWidth || !parentHeight) {
-            throw new Error('SVG dimensions must be postive values ' + this.element.outerHTML);
+            throw new Error(`SVG dimensions must be positive values. Received width: ${parentWidth} and height: ${parentHeight}`);
         }
         let desiredWidth = parentWidth - this.margin * 2;
         let desiredHeight = parentHeight - this.margin * 2;

--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -166,7 +166,7 @@ class D3SeatingChart {
     bindEvents() {
         let self = this;
         this.selectElements('[zoom-control]').on('click', (d) => {
-            let ele = d3.event.srcElement;
+            let ele = d3.event.srcElement || d3.event.target;
             let expose = ele.getAttribute('zoom-control');
             if (expose) {
                 this.zoom(this.selectElement(`[zoom-target="${expose}"]`));

--- a/src/D3SeatingChart.ts
+++ b/src/D3SeatingChart.ts
@@ -29,7 +29,7 @@ export class D3SeatingChart {
   private config: D3SeatingChartConfig;
 
   private uniqueIdentifier: string;
-  
+
   private constructor(private element: HTMLElement, private margin: number = 20) {}
 
   private init(config: D3SeatingChartConfig) {
@@ -52,7 +52,7 @@ export class D3SeatingChart {
 
   public stripStyles(selector: string) {
     let svgSelection = d3.select(this.element);
-    
+
     svgSelection.selectAll(selector)
       .attr('stroke', null)
       .attr('stroke-width', null)
@@ -144,10 +144,12 @@ export class D3SeatingChart {
     let activeLayer = selection.selectAll('.focused > *');
 
     // resize
-    
+
     let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
     let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
-    if (!parentWidth || !parentHeight) return;
+    if (!parentWidth || !parentHeight) {
+      throw new Error(`SVG dimensions must be positive values. Received width: ${parentWidth} and height: ${parentHeight}`);
+    }
 
     let desiredWidth = parentWidth - this.margin*2;
     let desiredHeight = parentHeight - this.margin*2;
@@ -156,11 +158,11 @@ export class D3SeatingChart {
     let heightRatio = desiredHeight / boundingBox.height;
 
     let ratio = Math.min(widthRatio, heightRatio);
-    
+
     scaleTransform = `scale(${ratio})`;
-    
+
     // center
-    
+
     let newX = (parentWidth / 2 - boundingBox.width * ratio / 2 - boundingBox.x * ratio);
     let newY = (parentHeight / 2 - boundingBox.height * ratio / 2 - boundingBox.y * ratio);
 
@@ -187,7 +189,7 @@ export class D3SeatingChart {
         .duration(animate ? 300 : 0)
         .style('opacity', 1);
     }
-      
+
     //activeLayer.style('pointer-events', 'inherit');
 
     boardSelection.transition()
@@ -233,7 +235,7 @@ export class D3SeatingChart {
     let self = this;
 
     this.selectElements('[zoom-control]').on('click', (d) => {
-      let ele = d3.event.srcElement;
+      let ele = d3.event.srcElement || d3.event.target;
       let expose = ele.getAttribute('zoom-control');
 
       if(expose) {
@@ -376,7 +378,7 @@ export class D3SeatingChart {
     let sortedSeats = seats.sort((a, b) => {
       let aX = Math.round(parseFloat(a.getAttribute('x')));
       let aY = Math.round(parseFloat(a.getAttribute('y')));
-      
+
       let bX = Math.round(parseFloat(b.getAttribute('x')));
       let bY = Math.round(parseFloat(b.getAttribute('y')));
 
@@ -481,7 +483,7 @@ export class D3SeatingChart {
 
           lastSeat = seat;
         }
-        
+
         if(br == -1) {
           sections.push(sortedSeatsCopy.splice(0, sortedSeatsCopy.length));
         } else {
@@ -497,7 +499,7 @@ export class D3SeatingChart {
         }
       }
     }
-    
+
     if(!contiguous || scatterFallback) {
       return sortedSeats.filter(x => !x.hasAttribute('locked')).splice(0, numSeats);
     }

--- a/test/d3sc.bundle.js
+++ b/test/d3sc.bundle.js
@@ -168,7 +168,7 @@ class D3SeatingChart {
     bindEvents() {
         let self = this;
         this.selectElements('[zoom-control]').on('click', (d) => {
-            let ele = d3.event.srcElement;
+            let ele = d3.event.srcElement || d3.event.target;
             let expose = ele.getAttribute('zoom-control');
             if (expose) {
                 this.zoom(this.selectElement(`[zoom-target="${expose}"]`));

--- a/test/test.bundle.js
+++ b/test/test.bundle.js
@@ -168,7 +168,7 @@ class D3SeatingChart {
     bindEvents() {
         let self = this;
         this.selectElements('[zoom-control]').on('click', (d) => {
-            let ele = d3.event.srcElement;
+            let ele = d3.event.srcElement || d3.event.target;
             let expose = ele.getAttribute('zoom-control');
             if (expose) {
                 this.zoom(this.selectElement(`[zoom-target="${expose}"]`));


### PR DESCRIPTION
`srcElement` is non-standard and is not supported in older versions of firefox [(see here)](https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement).

This will fall back on `event.target`, which is standard.  This PR also updates the typescript files to be up-to-date with the js files.